### PR TITLE
PR Analysis: calculate and return percentage change

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -38,17 +38,20 @@ RUN /app/orion-venv/bin/pip install --upgrade pip setuptools && \
 # Create symlink for orion command
 RUN ln -sf /app/orion-venv/bin/orion /usr/local/bin/orion
 
-# Copy orion-mcp source code
-ADD . /app/orion-mcp/
-
 # Create virtual environment for orion-mcp
 RUN python -m venv /app/orion-mcp-venv
 ENV ORION_MCP_VENV="/app/orion-mcp-venv"
+
+# Copy only requirements.txt first to leverage layers cache
+COPY requirements.txt /app/orion-mcp/requirements.txt
 
 # Install orion-mcp dependencies in its virtual environment
 WORKDIR /app/orion-mcp
 RUN /app/orion-mcp-venv/bin/pip install --upgrade pip && \
     /app/orion-mcp-venv/bin/pip install -r requirements.txt
+
+# Copy orion-mcp source code
+COPY . /app/orion-mcp/
 
 # Create /orion/examples directory and copy examples from the cloned orion repo
 RUN mkdir -p /orion && cp -r /app/orion-repo/examples /orion/examples

--- a/orion_mcp.py
+++ b/orion_mcp.py
@@ -196,14 +196,17 @@ async def get_pr_details(organization: str, repository: str, pull_request: str, 
         "trt-external-payload-crd-scale.yaml",
     ]
 
-    input_vars = {"jobtype": "pull",
-            "organization": organization,
-            "repository": repository,
-            "pull_number": pull_request,
-            "version": version}
+    input_vars = {
+        "jobtype": "pull",
+        "organization": organization,
+        "repository": repository,
+        "pull_number": pull_request,
+        "version": version
+    }
             
     full_config_paths = [os.path.join(ORION_CONFIGS_PATH, config) for config in configs]
     summaries: list[dict] = []
+    
     for full_config_path in full_config_paths:
         result = await run_orion(
             lookback=lookback,
@@ -212,45 +215,48 @@ async def get_pr_details(organization: str, repository: str, pull_request: str, 
             version=version,
             input_vars=input_vars
         )
-        data=json.loads(result.stdout)
+        data = json.loads(result.stdout)
+        
         if "periodic_avg" not in data or "pull" not in data:
-            return types.TextContent(type="text", text="Having issues finding PR data, please ensure the version the PR was tested on is correct and the PR was tested against the correct version of OpenShift.")
+            return types.TextContent(
+                type="text", 
+                text="Having issues finding PR data, please ensure the version the PR was tested on is correct and the PR was tested against the correct version of OpenShift."
+            )
                 
-        # Calculate percentage_change for each metric in pull section
         pull_data = data["pull"]
         periodic_avg = data["periodic_avg"]
         
-        # Iterate through each pull entry and calculate percentage_change for its metrics
+        # Add percentage changes to all metrics in pull data
         for pull_entry in pull_data:
-            if "metrics" in pull_entry:
-                for metric_name, metric_data in pull_entry["metrics"].items():
-                    # Find corresponding metric in periodic_avg
-                    if metric_name in periodic_avg:
-                        # periodic_avg values might be numbers or dicts with "value" key
-                        periodic_data = periodic_avg[metric_name]
-                        if isinstance(periodic_data, dict):
-                            periodic_value = periodic_data.get("value", 0)
-                        else:
-                            periodic_value = periodic_data
-                        
-                        pull_value = metric_data.get("value", 0)
-                        
-                        # Calculate percentage change: ((pull - periodic) / periodic) * 100
-                        if periodic_value != 0 and pull_value is not None and periodic_value is not None:
-                            percentage_change = ((pull_value - periodic_value) / periodic_value) * 100
-                            metric_data["percentage_change"] = percentage_change
-                        else:
-                            # If periodic value is 0, we can't calculate a meaningful percentage
-                            metric_data["percentage_change"] = 0
+            if "metrics" not in pull_entry:
+                continue
+                
+            for metric_name, metric_data in pull_entry["metrics"].items():
+                # Extract periodic value
+                if metric_name not in periodic_avg:
+                    periodic_value = 0
+                else:
+                    periodic_data = periodic_avg[metric_name]
+                    if isinstance(periodic_data, dict):
+                        periodic_value = periodic_data.get("value", 0)
                     else:
-                        # Metric not found in periodic_avg
-                        metric_data["percentage_change"] = 0
+                        periodic_value = periodic_data
+                
+                # Calculate percentage change
+                pull_value = metric_data.get("value", 0)
+                if periodic_value != 0 and pull_value is not None and periodic_value is not None:
+                    percentage_change = ((pull_value - periodic_value) / periodic_value) * 100
+                else:
+                    percentage_change = 0
+                
+                metric_data["percentage_change"] = percentage_change
         
         summaries.append({
             "config": full_config_path,
             "periodic_avg": periodic_avg,
             "pull": pull_data
         })
+    
     return summaries
 
 @mcp.tool()


### PR DESCRIPTION
This change introduces calculation of the "percentage_change" field in the openshift_report_on_pr MCP endpoint using the formula:
`percentage_change = ((pull_value - periodic_value) / periodic_value) * 100`

Assisted-by: Cursor / Claude 4.5 Sonnet

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Metrics now include percentage-change calculations vs. periodic averages.
  * Robust handling for missing or zero periodic values to avoid invalid results.

* **Chores**
  * Added a dedicated launcher and default runtime setup to simplify container execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->