### PR TITLE
Enhance openshift_report_on with custom metadata

### DIFF
--- a/orion_mcp.py
+++ b/orion_mcp.py
@@ -110,6 +110,8 @@ async def openshift_report_on(
     lookback: Annotated[str, Field(description="Number of days to lookback")] = "15",
     metric: Annotated[str, Field(description="Metric to analyze")] = "podReadyLatency_P99",
     config: Annotated[str, Field(description="Config to analyze")] = "small-scale-udn-l3.yaml",
+    display: Annotated[str, Field(description="Optional field to display in output (e.g., 'ocpVirtVersion')")] = "",
+    output_format: Annotated[str, Field(description="Output format: 'image' for plot, 'json' for data, 'both' for both")] = "image",
 ) -> types.ImageContent | types.TextContent:
     """
     Captures a performance analysis against the specified OpenShift version using Orion.
@@ -134,6 +136,7 @@ async def openshift_report_on(
         version_list = list(versions)
 
     series: dict[str, list[float]] = {}
+    full_data: dict[str, dict] = {}  # Store full summarized data for JSON output
 
     for ver in version_list:
         result = await run_orion(
@@ -141,6 +144,7 @@ async def openshift_report_on(
             config=ORION_CONFIGS_PATH + config,
             data_source=get_data_source(),
             version=ver,
+            display=display if display.strip() else None,
         )
 
         sum_result = await summarize_result(result, isolate=metric)
@@ -159,15 +163,45 @@ async def openshift_report_on(
             return types.TextContent(type="text", text=f"All values are None for version {ver}")
 
         series[ver] = values
+        full_data[ver] = sum_result  # Store full data for JSON output
         print(f"series: {series}")
 
-    # Generate multi-line plot
-    try:
-        img_b64 = generate_multi_line_plot(series, metric, title_prefix=f"{config}: ")
-    except ValueError as e:
-        return types.TextContent(type="text", text=str(e))
+    # Handle different output formats
+    if output_format.lower() == "json":
+        # Return JSON data
+        json_output = {
+            "config": config,
+            "metric": metric,
+            "lookback": lookback,
+            "display": display if display.strip() else None,
+            "data": full_data
+        }
+        return types.TextContent(type="text", text=json.dumps(json_output, indent=2))
 
-    return types.ImageContent(type="image", data=img_b64.decode("utf-8"), mimeType="image/jpeg")
+    elif output_format.lower() == "both":
+        # Return both JSON and image info
+        json_output = {
+            "config": config,
+            "metric": metric,
+            "lookback": lookback,
+            "display": display if display.strip() else None,
+            "data": full_data,
+            "plot_info": "Image data follows JSON data"
+        }
+        try:
+            img_b64 = generate_multi_line_plot(series, metric, title_prefix=f"{config}: ")
+            combined_output = json.dumps(json_output, indent=2) + "\n\n[IMAGE_DATA_BASE64]\n" + img_b64.decode("utf-8")
+            return types.TextContent(type="text", text=combined_output)
+        except ValueError as e:
+            return types.TextContent(type="text", text=f"Error generating plot: {str(e)}\n\nJSON data:\n{json.dumps(json_output, indent=2)}")
+
+    else:
+        # Default: return image
+        try:
+            img_b64 = generate_multi_line_plot(series, metric, title_prefix=f"{config}: ")
+            return types.ImageContent(type="image", data=img_b64.decode("utf-8"), mimeType="image/jpeg")
+        except ValueError as e:
+            return types.TextContent(type="text", text=str(e))
 
 async def get_pr_details(organization: str, repository: str, pull_request: str, version: str = "4.20", lookback: str = "15") -> list[dict]:
     """

--- a/orion_mcp.py
+++ b/orion_mcp.py
@@ -110,8 +110,7 @@ async def openshift_report_on(
     lookback: Annotated[str, Field(description="Number of days to lookback")] = "15",
     metric: Annotated[str, Field(description="Metric to analyze")] = "podReadyLatency_P99",
     config: Annotated[str, Field(description="Config to analyze")] = "small-scale-udn-l3.yaml",
-    display: Annotated[str, Field(description="Optional field to display in output (e.g., 'ocpVirtVersion')")] = "",
-    output_format: Annotated[str, Field(description="Output format: 'image' for plot, 'json' for data, 'both' for both")] = "image",
+    options: Annotated[str, Field(description="Options in format 'output_format' or 'output_format:display_field'. Examples: 'image', 'json', 'both', 'json:ocpVirtVersion'")] = "image",
 ) -> types.ImageContent | types.TextContent:
     """
     Captures a performance analysis against the specified OpenShift version using Orion.
@@ -120,14 +119,23 @@ async def openshift_report_on(
     configuration file to detect any performance regressions.
 
     Args:
-        version: Comma-separated list of OpenShift versions to analyze.
+        versions: Comma-separated list of OpenShift versions to analyze.
         lookback: The number of days to look back for performance data. Defaults to 15 days.
-        metric: The metric to analyze. Defaults to CPU.
-        config: The config to analyze. Defaults to trt-external-payload-cluster-density.yaml.
+        metric: The metric to analyze. Defaults to podReadyLatency_P99.
+        config: The config to analyze. Defaults to small-scale-udn-l3.yaml.
+        options: Output format and optional display field. Format: 'output_format' or
+                'output_format:display_field'. Examples: 'image', 'json:ocpVirtVersion'.
 
     Returns:
-        Returns an image showing the performance overtime.
+        Returns an image showing the performance overtime, or JSON data based on options.
     """
+
+    # Parse options to extract output_format and display
+    if ":" in options:
+        output_format, display = options.split(":", 1)
+    else:
+        output_format = options
+        display = ""
 
     # Parse versions into list
     if isinstance(versions, str):
@@ -138,12 +146,12 @@ async def openshift_report_on(
     series: dict[str, list[float]] = {}
     full_data: dict[str, dict] = {}  # Store full summarized data for JSON output
 
+    errors = []
     for ver in version_list:
         result = await run_orion(
-            lookback=lookback,
             config=ORION_CONFIGS_PATH + config,
-            data_source=get_data_source(),
             version=ver,
+            lookback=lookback,
             display=display if display.strip() else None,
         )
 
@@ -151,20 +159,26 @@ async def openshift_report_on(
 
         # Ensure we have the expected structure before indexing
         if not isinstance(sum_result, dict) or metric not in sum_result:
-            return types.TextContent(type="text", text=f"No data for version {ver}: {sum_result}")
+            errors.append(f"No data for version {ver}: {sum_result}")
+            continue
 
         raw_values = sum_result[metric].get("value", [])  # type: ignore[assignment]
         if not isinstance(raw_values, list):
-            return types.TextContent(type="text", text=f"Unexpected data format for version {ver}")
+            errors.append(f"Unexpected data format for version {ver}")
+            continue
 
         # Remove None values to keep the plot continuous
         values = [v for v in raw_values if v is not None]
         if not values:
-            return types.TextContent(type="text", text=f"All values are None for version {ver}")
+            errors.append(f"All values are None for version {ver}")
+            continue
 
         series[ver] = values
         full_data[ver] = sum_result  # Store full data for JSON output
         print(f"series: {series}")
+
+    if errors and not series:
+        return types.TextContent(type="text", text="\n".join(errors))
 
     # Handle different output formats
     if output_format.lower() == "json":
@@ -178,7 +192,7 @@ async def openshift_report_on(
         }
         return types.TextContent(type="text", text=json.dumps(json_output, indent=2))
 
-    elif output_format.lower() == "both":
+    if output_format.lower() == "both":
         # Return both JSON and image info
         json_output = {
             "config": config,
@@ -240,10 +254,9 @@ async def get_pr_details(organization: str, repository: str, pull_request: str, 
     summaries: list[dict] = []
     for full_config_path in full_config_paths:
         result = await run_orion(
-            lookback=lookback,
             config=full_config_path,
-            data_source=get_data_source(),
             version=version,
+            lookback=lookback,
             input_vars=input_vars
         )
         data=json.loads(result.stdout)
@@ -337,10 +350,9 @@ async def _run_regression_checks(
 
     for full_config_path in full_config_paths:
         result = await run_orion(
-            lookback=lookback,
             config=full_config_path,
-            data_source=get_data_source(),
             version=version,
+            lookback=lookback,
         )
 
         if result.returncode not in (0, 3):
@@ -440,10 +452,9 @@ async def metrics_correlation(
 
     # Run Orion to gather data
     result = await run_orion(
-        lookback=lookback,
         config=ORION_CONFIGS_PATH + config,
-        data_source=get_data_source(),
         version=version,
+        lookback=lookback,
     )
 
     summary = await summarize_result(result)

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -101,6 +101,7 @@ async def run_orion(
     data_source: str,
     version: str,
     input_vars: Optional[dict] = None,
+    display: Optional[str] = None,
 ) -> subprocess.CompletedProcess:
     """
     Execute Orion to analyze performance data for regressions.
@@ -110,6 +111,7 @@ async def run_orion(
         config: Path to the Orion configuration file to use for analysis.
         data_source: Location of the data (OpenSearch URL) to analyze.
         version: Version to analyze.
+        display: Optional field to display in the output (e.g., "ocpVirtVersion").
 
     Returns:
         The result of the Orion command execution, including stdout and stderr.
@@ -142,6 +144,10 @@ async def run_orion(
     if input_vars is not None:
         command.append("--input-vars")
         command.append(f"{json.dumps(input_vars)}")
+
+    if display is not None and display.strip():
+        command.append("--display")
+        command.append(display.strip())
 
     es_metadata_index = resolve_env_var(
         "es_metadata_index",
@@ -176,15 +182,21 @@ async def summarize_result(result: subprocess.CompletedProcess, isolate: Optiona
 
     Args:
         result: The json output from the Orion command.
+        isolate: Optional metric name to isolate for backwards compatibility.
 
     Returns:
-        A dictionary containing the summary of the Orion analysis.
+        A dictionary containing the summary of the Orion analysis with full run data preserved.
     """
     summary = {}
     try:
         data = json.loads(result.stdout)
         if len(data) == 0:
             return {}
+
+        # Store all runs with full data
+        summary["runs"] = data
+
+        # For backwards compatibility, also provide metric-focused summary
         for run in data:
             for metric_name, metric_data in run["metrics"].items():
                 summary["timestamp"] = run["timestamp"]

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -96,10 +96,10 @@ def orion_configs(configs: list[str]) -> list[str]:
     return [os.path.basename(cfg) for cfg in configs]
 
 async def run_orion(
-    lookback: str,
     config: str,
-    data_source: str,
     version: str,
+    lookback: str,
+    *,
     input_vars: Optional[dict] = None,
     display: Optional[str] = None,
 ) -> subprocess.CompletedProcess:
@@ -116,6 +116,7 @@ async def run_orion(
     Returns:
         The result of the Orion command execution, including stdout and stderr.
     """
+    data_source = get_data_source()
     if data_source == "":
         raise ValueError("Data source is not set")
     command = []
@@ -248,10 +249,9 @@ async def orion_metrics(config_list: list) -> dict | str:
     for config in config_list:
         metrics[config] = []
         result = await run_orion(
-            lookback="15", 
             config=config,
-            data_source=get_data_source(),
-            version="4.19"
+            version="4.19",
+            lookback="15"
         )
         try:
             sum_result = await summarize_result(result)


### PR DESCRIPTION
## Changes 
- Customizable field display option for OpenShift report outputs
- Multiple output format support: image plots, JSON data, or combined JSON + image
- Enhanced report generation flexibility with improved data handling and output customization

## Result:

> Show me the kubeApi CPU usage of the last 5 results of OCP 4.19 on the daily virtualization bare metal runs and display the corresponding openshift virtualization version, without images.
> I'll retrieve the kubeApi CPU usage data for the last 5 OCP 4.19 virtualization bare metal runs with their corresponding OpenShift virtualization versions.
> Perfect! Now I have the detailed data with the OpenShift virtualization versions. Here are the kubeApi CPU usage results for the last 5 OCP 4.19 daily virtualization bare metal runs:


### **Configuration: metal-perfscale-cpt-virt-density.yaml** (Standard Virtualization Density)

| Run | kubeApi CPU Usage | OpenShift Virtualization Version | OCP Version | Date |
|-----|-------------------|-----------------------------------|-------------|------|
| 1 (Most Recent) | **25.44%** | **4.19.15-9** | 4.19.0-0.nightly-2025-11-15-153535 | Nov 15, 2025 |
| 2 | **27.07%** | **4.19.15-9** | 4.19.0-0.nightly-2025-11-14-085636 | Nov 14, 2025 |
| 3 | **27.41%** | **4.19.15-7** | 4.19.0-0.nightly-2025-11-13-123920 | Nov 13, 2025 |
| 4 | **26.29%** | **4.19.15-4** | 4.19.0-0.nightly-2025-11-07-214657 | Nov 10, 2025 |
| 5 | **26.48%** | **4.19.14-11** | 4.19.0-0.nightly-2025-11-07-214657 | Nov 8, 2025 |

### **Configuration: metal-perfscale-cpt-virt-udn-density.yaml** (UDN Virtualization Density)

| Run | kubeApi CPU Usage | OpenShift Virtualization Version | OCP Version | Date |
|-----|-------------------|-----------------------------------|-------------|------|
| 1 (Most Recent) | **18.33%** | **4.19.15-9** | 4.19.0-0.nightly-2025-11-15-153535 | Nov 15, 2025 |
| 2 | **18.09%** | **4.19.15-9** | 4.19.0-0.nightly-2025-11-14-085636 | Nov 14, 2025 |
| 3 | **20.07%** | **4.19.15-7** | 4.19.0-0.nightly-2025-11-13-123920 | Nov 13, 2025 |
| 4 | **17.64%** | **4.19.15-4** | 4.19.0-0.nightly-2025-11-07-214657 | Nov 10, 2025 |
| 5 | **19.50%** | **4.19.14-11** | 4.19.0-0.nightly-2025-11-07-214657 | Nov 8, 2025 |

Assisted-by: Claude 🤖

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Customizable field display option for OpenShift report outputs
  * Multiple output format support: image plots, JSON data, or combined JSON + image
  * Enhanced report generation flexibility with improved data handling and output customization

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Configurable output format: generate image plots, retrieve JSON data, or both simultaneously
  * Optional display field parameter to customize report output content

* **Improvements**
  * Enhanced error handling: processing continues when individual items fail, returning available data alongside error details

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->