### PR TITLE
Set workdir explicitly to /tmp for orion

### DIFF
--- a/utils/utils.py
+++ b/utils/utils.py
@@ -38,17 +38,20 @@ def resolve_env_var(primary_name: str, secondary_name: str, default_value: str) 
 
     return default_value
 
-async def run_command_async(command: list[str] | str, env: Optional[dict] = None, shell: bool = False) -> subprocess.CompletedProcess:
+async def run_command_async(command: list[str] | str, env: Optional[dict] = None, shell: bool = False, cwd: Optional[str] = None) -> subprocess.CompletedProcess:
     """
     Run a command line tool asynchronously and return a CompletedProcess-like result.
     Args:
         command: List of command arguments or a single string for shell=True.
         env: Optional environment variables to set for the command.
         shell: Whether to use the shell to execute the command.
+        cwd: Optional working directory for the command.
     Returns:
         A subprocess.CompletedProcess-like object with args, returncode, stdout, stderr.
     """
     print(f"Running command: {command}")
+    if cwd:
+        print(f"Working directory: {cwd}")
     if env is not None:
         env_vars = os.environ.copy()
         env_vars.update(env)
@@ -62,7 +65,8 @@ async def run_command_async(command: list[str] | str, env: Optional[dict] = None
                 command,
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.PIPE,
-                env=env_vars
+                env=env_vars,
+                cwd=cwd
             )
         else:
             if not isinstance(command, list):
@@ -71,7 +75,8 @@ async def run_command_async(command: list[str] | str, env: Optional[dict] = None
                 *command,
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.PIPE,
-                env=env_vars
+                env=env_vars,
+                cwd=cwd
             )
         stdout, stderr = await process.communicate()
         result = subprocess.CompletedProcess(
@@ -169,7 +174,7 @@ async def run_orion(
     }
 
     print(f"Env: {env}")
-    result = await run_command_async(command, env=env)
+    result = await run_command_async(command, env=env, cwd="/tmp")
     # Log the full result for debugging
     print(f"Orion return code: {result.returncode}")
     print(f"Orion stdout: {result.stdout}")

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -12,7 +12,6 @@ import json
 import os
 import shutil
 import subprocess
-import tempfile
 from typing import Optional
 
 import matplotlib.pyplot as plt
@@ -39,19 +38,20 @@ def resolve_env_var(primary_name: str, secondary_name: str, default_value: str) 
 
     return default_value
 
-async def run_command_async(command: list[str] | str, cwd: str, env: Optional[dict] = None, shell: bool = False) -> subprocess.CompletedProcess:
+async def run_command_async(command: list[str] | str, env: Optional[dict] = None, shell: bool = False, cwd: Optional[str] = None) -> subprocess.CompletedProcess:
     """
     Run a command line tool asynchronously and return a CompletedProcess-like result.
     Args:
         command: List of command arguments or a single string for shell=True.
-        cwd: Working directory for the command. Required to ensure isolation and prevent race conditions.
         env: Optional environment variables to set for the command.
         shell: Whether to use the shell to execute the command.
+        cwd: Optional working directory for the command.
     Returns:
         A subprocess.CompletedProcess-like object with args, returncode, stdout, stderr.
     """
     print(f"Running command: {command}")
-    print(f"Working directory: {cwd}")
+    if cwd:
+        print(f"Working directory: {cwd}")
     if env is not None:
         env_vars = os.environ.copy()
         env_vars.update(env)
@@ -174,26 +174,12 @@ async def run_orion(
     }
 
     print(f"Env: {env}")
-    
-    # Create a unique temporary directory for this request to avoid
-    # race conditions when multiple requests run simultaneously
-    temp_dir = tempfile.mkdtemp(prefix="orion_", dir="/tmp")
-    print(f"Using temporary directory: {temp_dir}")
-    
-    try:
-        result = await run_command_async(command, env=env, cwd=temp_dir)
-        # Log the full result for debugging
-        print(f"Orion return code: {result.returncode}")
-        print(f"Orion stdout: {result.stdout}")
-        print(f"Orion stderr: {result.stderr}")
-        return result
-    finally:
-        # Clean up the temporary directory
-        try:
-            shutil.rmtree(temp_dir)
-            print(f"Cleaned up temporary directory: {temp_dir}")
-        except OSError as e:
-            print(f"Warning: Failed to clean up temporary directory {temp_dir}: {e}")
+    result = await run_command_async(command, env=env, cwd="/tmp")
+    # Log the full result for debugging
+    print(f"Orion return code: {result.returncode}")
+    print(f"Orion stdout: {result.stdout}")
+    print(f"Orion stderr: {result.stderr}")
+    return result
 
 
 async def summarize_result(result: subprocess.CompletedProcess, isolate: Optional[str] = None) -> dict | str:


### PR DESCRIPTION
When running orion-mcp in an OCP cluster, the calls fail with the following error: `PermissionError: [Errno 13] Permission denied: 'data-payload-cluster-density-v2.csv'.`
The root cause is orion creating CSV files in the current working directory when it runs. The Containerfile sets the working directory to /app/orion-mcp and this directory is owned by root and not writable by the random UID assigned by OCP.

This PR sets the working dir explicitly to /tmp, which is always writable regardless of security context.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Commands can now run from a specified working directory.

* **Improvements**
  * Diagnostic output now shows the working directory used during execution.
  * Orion now runs commands from a dedicated temporary directory for improved isolation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->