### PR TITLE
OpenShift deployment: use orion-mcp project, add a svc for internal comms

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,9 @@ podman build -t quay.io/YOUR_ORG/orion-mcp:latest .
 A production-ready `openshift-deployment.yml` is provided:
 
 ```bash
+# Create mcp project if required
+oc new-project orion-mcp
+
 # Update ES_SERVER env if required then apply
 oc apply -f openshift-deployment.yml
 

--- a/openshift-deployment.yml
+++ b/openshift-deployment.yml
@@ -1,10 +1,11 @@
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
     app.kubernetes.io/instance: orion-mcp 
   name: orion-mcp 
-  namespace: default
+  namespace: orion-mcp
 spec:
   progressDeadlineSeconds: 600
   replicas: 1
@@ -14,8 +15,8 @@ spec:
       app.kubernetes.io/name: orion-mcp 
   strategy:
     rollingUpdate:
-      maxSurge: 25%
-      maxUnavailable: 25%
+      maxSurge: 1
+      maxUnavailable: 0
     type: RollingUpdate
   template:
     metadata:
@@ -44,3 +45,23 @@ spec:
       schedulerName: default-scheduler
       securityContext: {}
       terminationGracePeriodSeconds: 30
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/instance: orion-mcp
+  name: orion-mcp
+  namespace: orion-mcp
+spec:
+  ports:
+  - name: http
+    port: 3030
+    protocol: TCP
+    targetPort: 3030
+  selector:
+    app.kubernetes.io/instance: orion-mcp
+    app.kubernetes.io/name: orion-mcp
+  type: ClusterIP
+


### PR DESCRIPTION
This PR introduces a dedicated orion-mcp namespace for the deployment and a service for the communication inside the cluster (see discussion in https://github.com/redhat-performance/BugZooka/pull/56).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added OpenShift project creation and deployment instructions to the README.

* **Chores**
  * Updated deployment configuration to use a dedicated project namespace and modified rolling update strategy for improved stability.
  * Added network service configuration for port 3030 access.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->