### PR TITLE
OpenShift deployment: use orion-mcp project, add a svc for internal comms

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,9 @@ podman build -t quay.io/YOUR_ORG/orion-mcp:latest .
 A production-ready `openshift-deployment.yml` is provided:
 
 ```bash
+# Create mcp project if required
+oc new-project orion-mcp
+
 # Update ES_SERVER env if required then apply
 oc apply -f openshift-deployment.yml
 
@@ -191,4 +194,3 @@ Pull requests are very welcome! Please ensure you have read and adhere to the [C
 ## License
 
 Orion-MCP is distributed under the **Apache 2.0** License. See the [LICENSE](LICENSE) file for full text.
-

--- a/openshift-deployment.yml
+++ b/openshift-deployment.yml
@@ -1,10 +1,11 @@
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
     app.kubernetes.io/instance: orion-mcp 
   name: orion-mcp 
-  namespace: default
+  namespace: orion-mcp
 spec:
   progressDeadlineSeconds: 600
   replicas: 1
@@ -14,8 +15,8 @@ spec:
       app.kubernetes.io/name: orion-mcp 
   strategy:
     rollingUpdate:
-      maxSurge: 25%
-      maxUnavailable: 25%
+      maxSurge: 1
+      maxUnavailable: 0
     type: RollingUpdate
   template:
     metadata:
@@ -44,3 +45,22 @@ spec:
       schedulerName: default-scheduler
       securityContext: {}
       terminationGracePeriodSeconds: 30
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/instance: orion-mcp
+  name: orion-mcp
+  namespace: orion-mcp
+spec:
+  ports:
+  - name: http
+    port: 3030
+    protocol: TCP
+    targetPort: 3030
+  selector:
+    app.kubernetes.io/instance: orion-mcp
+    app.kubernetes.io/name: orion-mcp
+  type: ClusterIP


### PR DESCRIPTION
This PR introduces a dedicated orion-mcp namespace for the deployment and a service for the communication inside the cluster.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated deployment guide with OpenShift project setup instructions.

* **Chores**
  * Updated OpenShift deployment configuration with new service resource, adjusted rolling update parameters for controlled rollouts, and dedicated namespace configuration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->