### PR TITLE
Add has_nightly_regressed tool for nightly-specific regression detection

### DIFF
--- a/orion_mcp.py
+++ b/orion_mcp.py
@@ -8,6 +8,7 @@ the cloud-bulldozer/orion library.
 import asyncio
 import json
 import os
+from datetime import datetime
 from typing import Annotated
 from pydantic import Field
 
@@ -23,7 +24,10 @@ from utils.utils import (
     orion_configs,
     generate_correlation_plot,
     generate_multi_line_plot,
-    list_orion_configs
+    list_orion_configs,
+    parse_nightly_version,
+    parse_timestamp,
+    filter_data_by_timestamp,
 )
 
 RELEASE_DATES = {
@@ -31,6 +35,8 @@ RELEASE_DATES = {
     "4.18": "2025-02-28",
     "4.19": "2025-06-17",
     "4.20": "2025-10-23",
+    "4.21": "2026-02-25",
+    "4.22": "2026-06-17",
 }
 
 mcp = FastMCP(name="orion-mcp",
@@ -514,6 +520,117 @@ async def metrics_correlation(
     corr_b64 = generate_correlation_plot(values1, values2, metric1, metric2, title_prefix=f"{config}: ")
 
     return types.ImageContent(type="image", data=corr_b64.decode("utf-8"), mimeType="image/jpeg")
+
+
+@mcp.tool()
+async def has_nightly_regressed(
+    nightly_version: Annotated[str, Field(description="Full nightly version string (e.g., '4.22.0-0.nightly-2026-01-05-203335')")],
+    previous_nightly: Annotated[str, Field(description="Optional previous nightly to compare against (e.g., '4.22.0-0.nightly-2026-01-01-123456')")] = "",
+    lookback: Annotated[str, Field(description="Number of days to lookback")] = "30",
+    configs: Annotated[str, Field(description="Comma-separated list of config files (optional, defaults to TRT configs)")] = "",
+) -> str:
+    """
+    Detect regressions for a specific OpenShift nightly version.
+
+    Parses the nightly version to extract major version and date, queries Orion,
+    filters data to the nightly date, and reports any changepoints found.
+
+    If previous_nightly is specified, only looks for regressions between the two nightlies.
+
+    Args:
+        nightly_version: Full nightly version string (e.g., '4.22.0-0.nightly-2026-01-05-203335').
+        previous_nightly: Optional previous nightly to compare against. If specified, only data
+                          between previous_nightly and nightly_version dates is analyzed.
+        lookback: Days to look back for data. Defaults to 30.
+        configs: Comma-separated list of config files. Defaults to TRT configs.
+
+    Returns:
+        String with regression details or "No regressions found".
+    """
+    # Parse the nightly version
+    try:
+        nightly_info = parse_nightly_version(nightly_version)
+    except ValueError as e:
+        return f"Error parsing nightly version: {e}"
+
+    if not nightly_info.is_nightly:
+        return f"Error: '{nightly_version}' is not a nightly version."
+
+    # Parse previous_nightly if specified
+    prev_nightly_info = None
+    if previous_nightly.strip():
+        try:
+            prev_nightly_info = parse_nightly_version(previous_nightly)
+        except ValueError as e:
+            return f"Error parsing previous_nightly: {e}"
+        if not prev_nightly_info.is_nightly:
+            return f"Error: '{previous_nightly}' is not a nightly version."
+        if prev_nightly_info.nightly_date >= nightly_info.nightly_date:
+            return "Error: previous_nightly must be earlier than nightly_version."
+
+    # Use default TRT configs if none specified
+    config_list = ([c.strip() for c in configs.split(",") if c.strip()] if configs.strip() else [
+        "trt-external-payload-cluster-density.yaml",
+        "trt-external-payload-node-density.yaml",
+        "trt-external-payload-node-density-cni.yaml",
+        "trt-external-payload-crd-scale.yaml",
+    ])
+
+    all_regressions: list[str] = []
+
+    for config in config_list:
+        full_config_path = os.path.join(ORION_CONFIGS_PATH, config)
+        result = await run_orion(config=full_config_path, version=nightly_info.major_version, lookback=lookback)
+
+        try:
+            data = json.loads(result.stdout)
+            if not isinstance(data, list):
+                continue
+            # Filter to entries on or before nightly date
+            data = filter_data_by_timestamp(data, nightly_info.nightly_date)
+            # If previous_nightly specified, also filter out entries before that date
+            if prev_nightly_info:
+                data = [e for e in data if e.get("timestamp") and _timestamp_after(e["timestamp"], prev_nightly_info.nightly_date)]
+        except (json.JSONDecodeError, TypeError):
+            continue
+
+        # Find changepoints and format output
+        for idx, entry in enumerate(data):
+            if not entry.get("is_changepoint"):
+                continue
+
+            # Build metric changes
+            metrics = []
+            for name, info in entry.get("metrics", {}).items():
+                pct = info.get("percentage_change", 0)
+                if pct != 0:
+                    metrics.append(f"{name} {'increased' if pct > 0 else 'decreased'} by {abs(pct):.2f}%")
+
+            prev = data[idx - 1] if idx > 0 else {}
+            prs_added = [p for p in (entry.get("prs") or []) if p not in (prev.get("prs") or [])]
+
+            lines = [
+                f"⚠️ Regression in {nightly_info.full_version}",
+                f"Config: {config}",
+                f"UUID: {entry.get('uuid')}",
+                f"Version: {entry.get('ocpVersion')} (prev: {prev.get('ocpVersion', 'N/A')})",
+            ]
+            if prev_nightly_info:
+                lines.insert(1, f"Comparing against: {prev_nightly_info.full_version}")
+            if prs_added:
+                lines.append(f"PRs: {', '.join(prs_added)}")
+            if metrics:
+                lines.append(f"Metrics: {'; '.join(metrics)}")
+
+            all_regressions.append("\n".join(lines))
+
+    return "\n\n".join(all_regressions) if all_regressions else "No regressions found"
+
+
+def _timestamp_after(timestamp_val, cutoff_datetime: datetime) -> bool:
+    """Check if a timestamp is after (not on or before) the cutoff datetime."""
+    entry_dt = parse_timestamp(timestamp_val)
+    return entry_dt is not None and entry_dt > cutoff_datetime
 
 
 def main():

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -10,8 +10,11 @@ import base64
 import io
 import json
 import os
+import re
 import shutil
 import subprocess
+from dataclasses import dataclass
+from datetime import datetime
 from typing import Optional
 
 import matplotlib.pyplot as plt
@@ -394,4 +397,120 @@ def generate_multi_line_plot(
     plt.close()
     buf.seek(0)
     return base64.b64encode(buf.read())
+
+
+# Nightly version parsing utilities
+
+@dataclass
+class NightlyVersionInfo:
+    """Information parsed from a nightly or GA version string."""
+    full_version: str           # "4.18.0-0.nightly-2025-01-15-203335" or "4.18"
+    major_version: str          # "4.18"
+    nightly_date: Optional[datetime]  # datetime(2025, 1, 15, 20, 33, 35) for nightlies, None for GA
+    is_nightly: bool            # True for nightlies, False for GA
+
+
+def parse_nightly_version(version_string: str) -> NightlyVersionInfo:
+    """
+    Parse a nightly or GA version string into structured information.
+
+    Nightly format: X.Y.Z-0.nightly-YYYY-MM-DD-HHMMSS (e.g., 4.18.0-0.nightly-2025-01-15-203335)
+    GA format: X.Y or X.Y.Z (e.g., 4.17 or 4.17.0)
+
+    Args:
+        version_string: The version string to parse.
+
+    Returns:
+        NightlyVersionInfo with parsed details.
+
+    Raises:
+        ValueError: If the version string format is invalid.
+    """
+    version_string = version_string.strip()
+
+    # Try to match nightly format: X.Y.Z-0.nightly-YYYY-MM-DD-HHMMSS
+    nightly_pattern = r'^(\d+)\.(\d+)\.(\d+)-0\.nightly-(\d{4})-(\d{2})-(\d{2})-(\d{6})$'
+    nightly_match = re.match(nightly_pattern, version_string)
+
+    if nightly_match:
+        major = nightly_match.group(1)
+        minor = nightly_match.group(2)
+        year = int(nightly_match.group(4))
+        month = int(nightly_match.group(5))
+        day = int(nightly_match.group(6))
+        time_str = nightly_match.group(7)  # HHMMSS format
+        hour = int(time_str[0:2])
+        minute = int(time_str[2:4])
+        second = int(time_str[4:6])
+
+        return NightlyVersionInfo(
+            full_version=version_string,
+            major_version=f"{major}.{minor}",
+            nightly_date=datetime(year, month, day, hour, minute, second),
+            is_nightly=True,
+        )
+
+    # Try to match GA format: X.Y or X.Y.Z
+    ga_pattern = r'^(\d+)\.(\d+)(?:\.(\d+))?$'
+    ga_match = re.match(ga_pattern, version_string)
+
+    if ga_match:
+        major = ga_match.group(1)
+        minor = ga_match.group(2)
+
+        return NightlyVersionInfo(
+            full_version=version_string,
+            major_version=f"{major}.{minor}",
+            nightly_date=None,
+            is_nightly=False,
+        )
+
+    raise ValueError(
+        f"Invalid version format: '{version_string}'. "
+        "Expected nightly format (e.g., '4.18.0-0.nightly-2025-01-15-123456') "
+        "or GA format (e.g., '4.17' or '4.17.0')."
+    )
+
+
+def parse_timestamp(timestamp_val) -> Optional[datetime]:
+    """
+    Parse a timestamp value into a datetime object.
+
+    Args:
+        timestamp_val: Unix timestamp (int/float), ISO string, or numeric string.
+
+    Returns:
+        Parsed datetime, or None if unparseable.
+    """
+    try:
+        if isinstance(timestamp_val, (int, float)):
+            return datetime.fromtimestamp(timestamp_val)
+        if isinstance(timestamp_val, str):
+            try:
+                return datetime.fromtimestamp(float(timestamp_val))
+            except ValueError:
+                ts_clean = timestamp_val.replace("Z", "").split("+")[0].split(".")[0]
+                return datetime.fromisoformat(ts_clean)
+    except (ValueError, TypeError, OSError):
+        pass
+    return None
+
+
+def filter_data_by_timestamp(data: list[dict], cutoff_datetime: datetime) -> list[dict]:
+    """
+    Filter Orion results to only include entries on or before the cutoff datetime.
+
+    Args:
+        data: List of Orion run dictionaries, each containing a 'timestamp' field.
+        cutoff_datetime: The cutoff datetime; entries after this are excluded.
+
+    Returns:
+        Filtered list containing only entries with timestamps on or before cutoff_datetime.
+    """
+    filtered = []
+    for entry in data:
+        entry_dt = parse_timestamp(entry.get("timestamp"))
+        if entry_dt and entry_dt <= cutoff_datetime:
+            filtered.append(entry)
+    return filtered
     


### PR DESCRIPTION
  PR description:
  ## Summary
  - Adds `has_nightly_regressed` MCP tool to detect regressions for a specific OpenShift nightly version
  - Parses nightly version to extract major version (e.g., 4.22) and date, then queries Orion and filters results
  - Supports optional `previous_nightly` parameter to narrow analysis to a specific time window between two nightlies

  ## Changes
  - `utils/utils.py`: Added `NightlyVersionInfo` dataclass, `parse_nightly_version()`, and `filter_data_by_timestamp()` utilities
  - `orion_mcp.py`: Added `has_nightly_regressed()` tool with parameters:
    - `nightly_version` (required): Full nightly string
    - `previous_nightly` (optional): Compare against a specific previous nightly
    - `lookback`: Days to look back (default: 30)
    - `configs`: Comma-separated config list (defaults to TRT configs)
  - Added release dates for 4.21 and 4.22

  ## Test plan
  - [ ] Run MCP server locally
  - [ ] Call `has_nightly_regressed` with a known nightly version
  - [ ] Verify it correctly parses the version and filters data by date
  - [ ] Test with `previous_nightly` to verify date range filtering
  - [ ] Confirm changepoints are detected and reported correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added nightly regression detection with configurable lookback, optional comparison to a previous nightly, and selectable configs.
  * Regression reports now include changepoint details (config, run ID, OCP versions, PRs added, and metric changes) and are filtered by nightly date.

* **Improvements**
  * Added utilities for parsing nightly versions and timestamps and for filtering data by timestamp.
  * Extended supported release dates to include 4.21 and 4.22.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->