### PR TITLE
Reduce container image size: two stage build and dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,78 @@
+# Git files
+.git
+.gitignore
+.gitattributes
+
+# Python cache and build artifacts
+__pycache__/
+*.py[cod]
+*$py.class
+*.so
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+pip-wheel-metadata/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# Virtual environments
+venv/
+env/
+ENV/
+.venv/
+.env
+
+# IDE and editor files
+.vscode/
+.idea/
+*.swp
+*.swo
+*~
+.DS_Store
+
+# Documentation
+*.md
+docs/
+
+# Testing and linting
+.pytest_cache/
+.coverage
+.coveragerc
+.tox/
+.cache
+pytest.ini
+.pylintrc
+tests/
+
+# Development tools config
+.pre-commit-config.yaml
+poetry.lock
+pyproject.toml
+.python-version
+
+# Logs
+*.log
+logs/
+
+# Temporary files
+*.tmp
+*.temp
+.tmp/
+.temp/
+
+# Misc files
+.github/
+openshift-deployment.yml

--- a/Containerfile
+++ b/Containerfile
@@ -10,7 +10,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 # Clone Orion repository
-RUN git clone --depth 1 --branch v0.1.5 http://github.com/cloud-bulldozer/orion /app/orion-repo
+RUN git clone --depth 1 --branch v0.1.5 https://github.com/cloud-bulldozer/orion /app/orion-repo
 
 # Create and populate Orion virtual environment
 RUN python -m venv /app/orion-venv
@@ -49,7 +49,8 @@ RUN ln -sf /app/orion-venv/bin/orion /usr/local/bin/orion
 COPY . /app/orion-mcp/
 
 # Create wrapper script
-RUN echo '#!/bin/bash\n/app/orion-mcp-venv/bin/python /app/orion-mcp/orion_mcp.py "$@"' > /usr/local/bin/orion-mcp && \
+RUN printf '%s\n' '#!/bin/sh' '/app/orion-mcp-venv/bin/python /app/orion-mcp/orion_mcp.py "$@"' \
+    > /usr/local/bin/orion-mcp && \
     chmod +x /usr/local/bin/orion-mcp
 
 WORKDIR /app/orion-mcp

--- a/Containerfile
+++ b/Containerfile
@@ -1,68 +1,57 @@
-FROM python:3.11.8-slim-bookworm
-# So that STDOUT/STDERR is printed
-ENV PYTHONUNBUFFERED="1"
+# ============================================================
+# Stage 1: Build stage - compile and install dependencies
+# ============================================================
+FROM python:3.11.8-slim-bookworm AS builder
 
-# First let's just get things updated.
-# Install System dependencies
-RUN apt-get update --assume-yes && \
-    apt-get install -o 'Dpkg::Options::=--force-confnew' -y --force-yes -q \
+RUN apt-get update && apt-get install -y --no-install-recommends \
     git \
-    openssh-client \
     gcc \
-    clang \
     build-essential \
-    make \
-    curl \
-    virtualenv \
-    python3-venv \
     && rm -rf /var/lib/apt/lists/*
-
-ENV PATH="~/bin:$PATH"
-
-# Create base directory structure
-RUN mkdir -p /app/orion /app/orion-mcp
 
 # Clone Orion repository
 RUN git clone --depth 1 --branch v0.1.5 http://github.com/cloud-bulldozer/orion /app/orion-repo
 
-# Create virtual environment for Orion
+# Create and populate Orion virtual environment
 RUN python -m venv /app/orion-venv
-ENV ORION_VENV="/app/orion-venv"
+RUN /app/orion-venv/bin/pip install --no-cache-dir --upgrade pip setuptools && \
+    /app/orion-venv/bin/pip install --no-cache-dir -r /app/orion-repo/requirements.txt && \
+    /app/orion-venv/bin/pip install --no-cache-dir /app/orion-repo
 
-# Install Orion in its virtual environment
-WORKDIR /app/orion-repo
-RUN /app/orion-venv/bin/pip install --upgrade pip setuptools && \
-    /app/orion-venv/bin/pip install -r requirements.txt && \
-    /app/orion-venv/bin/pip install .
+# Copy examples
+RUN mkdir -p /orion && cp -r /app/orion-repo/examples /orion/examples
+
+# Create orion-mcp virtual environment
+RUN python -m venv /app/orion-mcp-venv
+COPY requirements.txt /app/orion-mcp/requirements.txt
+RUN /app/orion-mcp-venv/bin/pip install --no-cache-dir --upgrade pip && \
+    /app/orion-mcp-venv/bin/pip install --no-cache-dir -r /app/orion-mcp/requirements.txt
+
+# ============================================================
+# Stage 2: Runtime stage - minimal final image
+# ============================================================
+FROM python:3.11.8-slim-bookworm
+
+ENV PYTHONUNBUFFERED="1"
+ENV ORION_VENV="/app/orion-venv"
+ENV ORION_MCP_VENV="/app/orion-mcp-venv"
+ENV PATH="/app/orion-mcp-venv/bin:$PATH"
+
+# Copy virtual environments from builder
+COPY --from=builder /app/orion-venv /app/orion-venv
+COPY --from=builder /app/orion-mcp-venv /app/orion-mcp-venv
+COPY --from=builder /orion/examples /orion/examples
 
 # Create symlink for orion command
 RUN ln -sf /app/orion-venv/bin/orion /usr/local/bin/orion
 
-# Create virtual environment for orion-mcp
-RUN python -m venv /app/orion-mcp-venv
-ENV ORION_MCP_VENV="/app/orion-mcp-venv"
-
-# Copy only requirements.txt first to leverage layers cache
-COPY requirements.txt /app/orion-mcp/requirements.txt
-
-# Install orion-mcp dependencies in its virtual environment
-WORKDIR /app/orion-mcp
-RUN /app/orion-mcp-venv/bin/pip install --upgrade pip && \
-    /app/orion-mcp-venv/bin/pip install -r requirements.txt
-
 # Copy orion-mcp source code
 COPY . /app/orion-mcp/
 
-# Create /orion/examples directory and copy examples from the cloned orion repo
-RUN mkdir -p /orion && cp -r /app/orion-repo/examples /orion/examples
-
-# Create a wrapper script to run orion-mcp with its virtual environment
+# Create wrapper script
 RUN echo '#!/bin/bash\n/app/orion-mcp-venv/bin/python /app/orion-mcp/orion_mcp.py "$@"' > /usr/local/bin/orion-mcp && \
     chmod +x /usr/local/bin/orion-mcp
 
 WORKDIR /app/orion-mcp
-
-# Use the orion-mcp virtual environment by default
-ENV PATH="/app/orion-mcp-venv/bin:$PATH"
 
 CMD ["/app/orion-mcp-venv/bin/python", "orion_mcp.py"]


### PR DESCRIPTION
This PR reduces container image size from 760 MB to 230 MB by introducing two stage build and a dockerignore file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Optimized container build for smaller, leaner runtime images and faster build times via multi-stage build improvements.
  * Reduced build/upload size by excluding development, test, and editor artifacts from the build context.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->